### PR TITLE
clarify latency is defined in samples

### DIFF
--- a/include/clap/ext/latency.h
+++ b/include/clap/ext/latency.h
@@ -10,7 +10,7 @@ extern "C" {
 
 // The audio ports scan has to be done while the plugin is deactivated.
 typedef struct clap_plugin_latency {
-   // Returns the plugin latency.
+   // Returns the plugin latency in samples.
    // [main-thread]
    uint32_t(CLAP_ABI *get)(const clap_plugin_t *plugin);
 } clap_plugin_latency_t;


### PR DESCRIPTION
using the same wording as in tail extension to clarify details.